### PR TITLE
Switched to xmlstarlet from miscscripts

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -3,7 +3,7 @@ function setupjq () {
 }
 
 function setupxmlstarlet () {
-  docker pull jakubsacha/docker-xmlstarlet
+  docker pull pnnlmiscscripts/xmlstarlet:1.6.1-2
 }
 
 function jq () {
@@ -11,7 +11,7 @@ function jq () {
 }
 
 function xmlstarlet () {
-  docker run -i --rm jakubsacha/docker-xmlstarlet "$@"
+  docker run -i --rm pnnlmiscscripts/xmlstarlet:1.6.1-2 "$@"
 }
 
 function startregistry () {


### PR DESCRIPTION
* Fixed docker manifest issues

Currently broken until the xmlstarlet image has a fixed entrypoint, probably will need to target 1.6.1-2 if there's some way to push with that version.